### PR TITLE
Refactor : Amélioration des specs pour ProductsController

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -47,7 +47,7 @@ class ProductsController < ApplicationController
   private
   def record_not_found
     flash[:alert] = "Produit introuvable"
-    redirect_to products_path, notice: "Produit introuvable"
+    redirect_to products_path, alert: "Produit introuvable"
   end
 
   private

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,11 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe ProductsController, type: :request do
+  let(:user) do
+            User.create!(
+              email_address: "test@example.com",
+              password: "azerty",
+              name: "test",
+              last_name: "name"
+            )
+          end
+    before(:all) do
+      Product.create!(name: "Pomme", description: "Pomme gala")
+      Product.create!(name: "Banane", description: "Banane")
+    end
+  before do
+          post session_path params: { email_address: user.email_address, password: user.password }  if user.present?
+  end
     describe "GET /products" do
-        before do
-            Product.create!(name: "Pomme", description: "Pomme gala")
-            Product.create!(name: "Banane", description: "Banane")
-        end
         it "send HTTP code 200" do
             get products_path
             expect(response).to have_http_status(:ok)
@@ -15,79 +26,67 @@ RSpec.describe ProductsController, type: :request do
             expect(response.body).to include("Banane")
             expect(response.body).to include("Pomme")
         end
-    end
+      end
     describe "GET /products empty" do
-    it "no products" do
-        Product.delete_all
-        get products_path
-        expect(response.body).to include("Aucun produit disponible")
-    end
+      before { Product.delete_all }
+      it "no products" do
+          get products_path
+          expect(response.body).to include("Aucun produit disponible")
+      end
     end
 
     describe "GET /products/new" do
-        let(:user) do
-            User.create!(
-              email_address: "test@example.com",
-              password: "azerty",
-              name: "test",
-              last_name: "name"
-            )
+          subject(:get_new_product) do
+            get new_product_path
           end
-          context "when user is authenticated" do
-            before do
-              # Simulate user authentication by setting the session cookie
-              post session_path params: { email_address: user.email_address, password: user.password }
-            end
-            it "displays the form" do
-              get new_product_path
-              expect(response).to have_http_status(:ok)
-              expect(response.body).to include('<form')
-              expect(response.body).to include('name="product[name]"')
-              expect(response.body).to include('name="product[description]"')
-            end
+          it "displays the form" do
+            get_new_product
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include('<form')
+            expect(response.body).to include('name="product[name]"')
+            expect(response.body).to include('name="product[description]"')
           end
           context "when user is not authenticated" do
+            let(:user) { nil }
             it "does not display the form and redirects to login" do
-              get new_product_path
-              expect(response).to have_http_status(:found) # Assuming it redirects to login
+              get_new_product
+              expect(response).to have_http_status(:found)
               expect(response).to redirect_to(new_session_path)
-              expect(response.body).not_to include('<form')
             end
           end
       end
       describe "POST /products" do
-        let(:user) do
-          User.create!(
-            email_address: "test@example.com",
-            password: "azerty",
-            name: "test",
-            last_name: "name"
-          )
+        let(:valid_attributes) do
+          {
+            name: "Pomme",
+            description: "Pomme gala"
+          }
         end
-        before do
-          # Simulate user authentication by setting the session cookie
-          post session_path params: { email_address: user.email_address, password: user.password }
+        let(:invalid_attributes) do
+          {
+            name: "",
+            description: ""
+          }
         end
-        let (:valid_attributes) { { name: "Pomme", description: "Pomme gala" } }
-        let (:invalid_attributes) { { name: "", description: "" } }
+        let(:attributes) { valid_attributes }
+        let(:params) do
+          { product: attributes }
+        end
+        subject(:post_product) do
+          post products_path, params: params
+        end
+
           it "create one product" do
-            # get products_new_path
-            product = Product.create(valid_attributes)
-            post products_path, params: { product: valid_attributes }
-            # 1. Vérifier que l'objet est conforme aux validations présentes dans le model.
-            expect(product).to be_valid
-            # 2. Vérifier que l'objet est bien save dans la base.
-            expect(product).to be_persisted
-            # 3. Vérifier que la réponse redirige vers la bonne page après la création.
-            expect(response).to have_http_status(:found)
-            # EN PLUS : tester le changement du nombre de rows en base de données.
-            expect { post products_path, params: { product: valid_attributes } }.to change(Product, :count).by(1)
+            expect { post_product }.to change { Product.count }.by(1)
+            expect(response).to have_http_status(302)
+            expect(response).to redirect_to(products_path)
           end
-          it "does not create one product" do
-            product = Product.create(invalid_attributes)
-            expect(product).not_to be_valid
-            expect(product.errors[:name]).to include("Le nom du produit ne peut pas être vide.")
-            expect(product.errors[:description]).to include("La description du produit ne peut pas être vide.")
+          context "when attributes are invalid" do
+            let(:attributes) { invalid_attributes }
+            it "does not create one product" do
+              expect { post_product }.not_to change { Product.count }
+              expect(response).to have_http_status(:unprocessable_entity)
+            end
           end
     end
     describe "GET /products/:id " do
@@ -98,99 +97,79 @@ RSpec.describe ProductsController, type: :request do
         expect(response.body).to include("Pomme")
         expect(response.body).to include("Description pomme")
       end
-      it "product doesn't exist" do
-        # Simule un ID inexistant qui provoque une exception
-        allow(Product).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
-        get products_path(id: 999)
-        expect(response).to have_http_status(:ok)
-        expect(response).not_to include('Pomme')
-        expect(response).not_to include('Description pomme')
-      end
-    end
-    describe "GET /products/:id/edit edit one product" do
-      let(:user) do
-        User.create!(
-          email_address: "test@example.com",
-          password: "azerty",
-          name: "test",
-          last_name: "name"
-        )
-      end
-      let(:product) { Product.create!(name: "Pomme", description: "Description pomme") }
-      before do
-        # Simulate user authentication by setting the session cookie
-        post session_path params: { email_address: user.email_address, password: user.password }
-      end
-      it "display the form" do
-        get edit_product_path(:id)
-        expect(response).to have_http_status(:found)
-      end
-      it "does not display the form and redirects to login" do
-        get edit_product_path(:id)
+      context "when the action fails" do
+        it "product doesn't exist" do
+        get product_path(id: 999)
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(products_path)
-        expect(response.body).not_to include('<form')
+        follow_redirect!
+        expect(response.body).to include("Produit introuvable")
+        end
+      end
+    end
+    describe "UPDATE /products/:id/edit edit one product" do
+      let(:product) { Product.create!(name: "Pomme", description: "Description pomme") }
+      it "display the form" do
+        get edit_product_path(product)
+        expect(response).to have_http_status(:ok)
+      end
+      context "when the user is not authenticated" do
+        let(:user) { nil }
+        it "does not display the form and redirects to login" do
+          get edit_product_path(product)
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(new_session_path)
+        end
       end
     end
     describe "PATCH /products/:id" do
-      it "user not auth" do
-        get product_path(:id)
-        expect(response).to have_http_status(:found)
-        # expect(response).to redirect_to(new_session_path)
-        # expect(response.body).not_to include('<form')
-      end
-      let(:user) do
-        User.create!(
-          email_address: "test@example.com",
-          password: "azerty",
-          name: "test",
-          last_name: "name"
-        )
-      end
-      before do
-        # Simulate user authentication by setting the session cookie
-        post session_path params: { email_address: user.email_address, password: user.password }
-      end
+      let (:product) { Product.create!(name: "Pomme", description: "Description pomme") }
+      let (:valid_params) { { product: { name: "Pomme verte", description: "Description de la pomme verte" } } }
         it "update one product" do
-          product = Product.create!(name: "Pomme", description: "Description pomme")
-          patch product_path(:id), params: { product: { name: "Pomme verte", description: "Description de la pomme verte" } }
+          patch product_path(product), params:  valid_params
           expect(response).to have_http_status(:found)
         end
+        context "when user not auth" do
+          let(:user) { nil }
+          it "does not display the form, redirect to login page" do
+            get product_path(product)
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(new_session_path)
+          end
+        end
+        context "when the product update fails" do
+          let(:invalid_params) { { product: { name: "", description: "" } } }
         it "does not update one product" do
-          patch product_path(:id), params: { product: { name: "", description: "" } }
-          expect(response).to redirect_to(products_path)
-          expect(flash[:alert]).to eq("Produit introuvable")
+            patch product_path(product), params: invalid_params
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
         end
     end
     describe "DELETE /products/:id" do
-      let(:user) do
-        User.create!(
-          email_address: "test@example.com",
-          password: "azerty",
-          name: "test",
-          last_name: "name"
-        )
+      let(:product) do
+        Product.create!(name: "Pomme", description: "Description pomme")
       end
-
-      before do
-        post session_path params: { email_address: user.email_address, password: user.password }
-      end
-
-      it "delete one product" do
-        product = Product.create!(name: "Pomme", description: "Description pomme")
+      subject(:delete_product) do
         delete product_path(product)
+      end
+      it "delete one product" do
+        delete_product
         expect(response).to have_http_status(:found)
         expect(Product.exists?(product.id)).to be_falsey
         expect(response).to redirect_to(products_path)
       end
 
-      it "does not delete one product if destroy fails" do
-        product = Product.create!(name: "Pomme", description: "Description pomme")
-        allow_any_instance_of(Product).to receive(:destroy).and_return(false)
-        delete product_path(product)
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(Product.exists?(product.id)).to be_truthy
-        expect(flash[:alert]).to eq("La suppression du produit a échoué.")
+      context "when destroy fails" do
+        before do
+          # mock
+          allow_any_instance_of(Product).to receive(:destroy).and_return(false)
+        end
+        it "does not delete one product" do
+          delete_product
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(Product.exists?(product.id)).to be_truthy
+          expect(flash[:alert]).to eq("La suppression du produit a échoué.")
+        end
       end
-    end
   end
+end


### PR DESCRIPTION
# Changements principaux 

-  Utilisation de `let` et `subject` : meilleure structure des tests et moins de duplication de code. 
- Contextes explicites : pour les utilisateur authentifié ou non. Meilleure lisibilité des tests.
- Suppression de mock inutile ( ligne 102, spec : "product does'nt exist"), utilisation seulement d'un ID qui n'existe pas en DB. 
- Rectification de l'indentation du fichier pour une  meilleure lisibilité.
- Vérification des status HTTP et des redirections. 